### PR TITLE
feat: optimize llm query v1

### DIFF
--- a/modules/llm-cache/ds/kv_cache.h
+++ b/modules/llm-cache/ds/kv_cache.h
@@ -104,6 +104,11 @@ class KVCacheBuilder : public vineyard::ObjectBuilder {
   Status Query(const std::vector<int>& token_list, int token,
                std::vector<std::pair<LLMKV, LLMKV>>& kv_state);
 
+  Status Query(const std::vector<int>& prefix,
+               const std::vector<int>& tokenList,
+               std::vector<std::vector<std::pair<LLMKV, LLMKV>>>& kvCacheList,
+               size_t& matched);
+
   void Delete(std::shared_ptr<NodeData> evicted_node);
 
   Status Merge(std::shared_ptr<KVCache> kv_cache);

--- a/modules/llm-cache/ds/kv_cache_block.h
+++ b/modules/llm-cache/ds/kv_cache_block.h
@@ -136,8 +136,17 @@ class KVCacheBlockBuilder : public ObjectBuilder {
   KVCacheBlockBuilder(Client& client,
                       std::shared_ptr<KVCacheBlock> kv_cache_block);
 
+  static Status Make(Client& client, const ObjectID blockObjectID,
+                     std::shared_ptr<KVCacheBlock> blockObject,
+                     KVCacheBlockBuilder*& kvCacheBlockBuilder);
+
   static Status Make(Client& client, TreeData* treeData,
                      KVCacheBlockBuilder*& kvCacheBlockBuilder);
+
+  static Status BulkQuery(
+      std::vector<KVCacheBlockBuilder*>& kvCacheBlockBuilders,
+      std::vector<int>& offsets,
+      std::vector<std::vector<std::pair<LLMKV, LLMKV>>>& kvCacheList);
 
   /**
    * @brief Update the kv-state using next token.

--- a/modules/llm-cache/radix-tree/radix-tree.h
+++ b/modules/llm-cache/radix-tree/radix-tree.h
@@ -72,6 +72,9 @@ class RadixTree : public std::enable_shared_from_this<RadixTree> {
 
   std::shared_ptr<NodeData> QueryInternal(const std::vector<int>& tokens);
 
+  std::vector<std::shared_ptr<NodeData>> QueryInternal(
+      const std::vector<int>& prefix, const std::vector<int>& tokens);
+
   std::vector<std::shared_ptr<NodeData>> SplitInternal(
       const std::vector<int>& tokens, std::shared_ptr<NodeData>& header);
 
@@ -87,6 +90,9 @@ class RadixTree : public std::enable_shared_from_this<RadixTree> {
               std::shared_ptr<NodeData>& evictedNode);
 
   std::shared_ptr<NodeData> Query(const std::vector<int>& tokens);
+
+  std::vector<std::shared_ptr<NodeData>> Query(const std::vector<int>& prefix,
+                                               const std::vector<int>& tokens);
 
   std::vector<std::shared_ptr<NodeData>> Split(
       const std::vector<int>& tokens, std::shared_ptr<NodeData>& header);

--- a/modules/llm-cache/storage/blob_storage.cc
+++ b/modules/llm-cache/storage/blob_storage.cc
@@ -423,8 +423,6 @@ Status BlobStorage::Query(
     const std::vector<int>& prefix, const std::vector<int>& tokenList,
     std::vector<std::vector<std::pair<LLMKV, LLMKV>>>& kvCacheList,
     size_t& matched) {
-  RETURN_ON_ASSERT(tokenList.size() == kvCacheList.size(),
-                   "tokenList size must matches kvCacheList size");
   std::unique_lock<std::mutex> lock(cacheAccessMutex, std::defer_lock);
   if (!lock.try_lock()) {
     return Status::Invalid("Query cache failed: can not gain the cache lock.");
@@ -432,16 +430,8 @@ Status BlobStorage::Query(
   if (isClosed) {
     return Status::Invalid("The memory storage is closed.");
   }
-  matched = 0;
-  std::vector<int> tokenListPrefix(prefix.begin(), prefix.end());
-  for (size_t i = 0; i < tokenList.size(); i++) {
-    auto status = QueryInternal(tokenListPrefix, tokenList[i], kvCacheList[i]);
-    if (!status.ok()) {
-      break;
-    }
-    matched += 1;
-    tokenListPrefix.push_back(tokenList[i]);
-  }
+
+  kvCacheBuilder->Query(prefix, tokenList, kvCacheList, matched);
   return Status::OK();
 }
 

--- a/thirdparty/rax/radix.h
+++ b/thirdparty/rax/radix.h
@@ -231,6 +231,8 @@ void* raxFind(rax* rax, const std::vector<int>& token_list);
 raxNode* raxFindAndReturnDataNode(rax* rax, const std::vector<int>& token_list,
                                   raxNode** sub_tree_node = NULL,
                                   bool set_timestamp = true);
+std::vector<raxNode*> raxFindAll(rax* rax, const std::vector<int>& token_list,
+                                 bool set_timestamp = true);
 void raxSetSubtree(raxNode* n);
 void raxSetSubtreeAllocated(raxNode* node);
 void raxSetSubtreeNotNull(raxNode* node);


### PR DESCRIPTION
- get objects' metadata in one shot
- traverse radix tree once for each query


