### PR TITLE
fix: rename to aibrix/v6d and fix workflows

### DIFF
--- a/.github/workflows/build-archlinux-latest.yml
+++ b/.github/workflows/build-archlinux-latest.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'aibrix/v6d' || github.event_name == 'workflow_dispatch' }}
     container:
       image: archlinux:latest
     strategy:

--- a/.github/workflows/build-centos-latest.yaml
+++ b/.github/workflows/build-centos-latest.yaml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'aibrix/v6d' || github.event_name == 'workflow_dispatch' }}
     container:
       image: centos:latest
     strategy:

--- a/.github/workflows/build-compatibility.yml
+++ b/.github/workflows/build-compatibility.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'aibrix/v6d' || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-11]

--- a/.github/workflows/build-test-graph.yml
+++ b/.github/workflows/build-test-graph.yml
@@ -38,7 +38,7 @@ env:
 jobs:
   ci:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' }}
+    if: ${{ github.repository == 'aibrix/v6d' }}
     strategy:
       matrix:
         os: [ubuntu-20.04]

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -40,7 +40,7 @@ env:
 jobs:
   ci:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' }}
+    if: ${{ github.repository == 'aibrix/v6d' }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -431,7 +431,7 @@ jobs:
 
       - name: Upload vineyard contrib wheels to tagged release
         uses: svenstaro/upload-release-action@v2
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/*vineyard*.whl

--- a/.github/workflows/build-vineyardd-and-wheels-linux.yaml
+++ b/.github/workflows/build-vineyardd-and-wheels-linux.yaml
@@ -24,6 +24,9 @@ concurrency:
   group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
 
+permissions:
+  packages: write
+
 jobs:
   build-vineyardd:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-vineyardd-and-wheels-linux.yaml
+++ b/.github/workflows/build-vineyardd-and-wheels-linux.yaml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   build-vineyardd:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'aibrix/v6d' || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -57,7 +57,7 @@ jobs:
         run: |
           make -C docker/ vineyardd ALPINE_VERSION=$ALPINE_VERSION PLATFORM=${{ matrix.platform }}
           docker run --rm \
-               -v `pwd`:/target ghcr.io/v6d-io/v6d/vineyardd:alpine-${ALPINE_VERSION}_${{ matrix.platform }} \
+               -v `pwd`:/target ghcr.io/aibrix/v6d/vineyardd:alpine-${ALPINE_VERSION}_${{ matrix.platform }} \
                sh -c "cp /usr/local/bin/vineyardd /target/"
           # ldd ./vineyardd
 
@@ -69,31 +69,31 @@ jobs:
           tar zcvfh vineyardd.${{ runner.os }}-${{ matrix.platform }}.${{ github.sha }}.tar.gz ./vineyardd vineyardd.${{ matrix.platform }}.${{ github.sha }}.sha512sum
 
       - name: Upload docker image as nightly
-        if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'aibrix/v6d' }}
         run: |
-          docker push ghcr.io/v6d-io/v6d/vineyardd:alpine-${{ github.sha }}_${{ matrix.platform }}
+          docker push ghcr.io/aibrix/v6d/vineyardd:alpine-${{ github.sha }}_${{ matrix.platform }}
 
       - name: Extract tag name
         id: tag
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Tag and upload docker for releases
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         run: |
-          docker tag ghcr.io/v6d-io/v6d/vineyardd:alpine-${{ github.sha }}_${{ matrix.platform }} \
-                     ghcr.io/v6d-io/v6d/vineyardd:alpine-${{ steps.tag.outputs.TAG }}_${{ matrix.platform }}
-          docker tag ghcr.io/v6d-io/v6d/vineyardd:alpine-${{ github.sha }}_${{ matrix.platform }} \
-                     ghcr.io/v6d-io/v6d/vineyardd:${{ steps.tag.outputs.TAG }}_${{ matrix.platform }}
-          docker tag ghcr.io/v6d-io/v6d/vineyardd:alpine-${{ github.sha }}_${{ matrix.platform }} \
-                     ghcr.io/v6d-io/v6d/vineyardd:alpine-latest_${{ matrix.platform }}
-          docker tag ghcr.io/v6d-io/v6d/vineyardd:alpine-${{ github.sha }}_${{ matrix.platform }} \
-                     ghcr.io/v6d-io/v6d/vineyardd:latest_${{ matrix.platform }}
+          docker tag ghcr.io/aibrix/v6d/vineyardd:alpine-${{ github.sha }}_${{ matrix.platform }} \
+                     ghcr.io/aibrix/v6d/vineyardd:alpine-${{ steps.tag.outputs.TAG }}_${{ matrix.platform }}
+          docker tag ghcr.io/aibrix/v6d/vineyardd:alpine-${{ github.sha }}_${{ matrix.platform }} \
+                     ghcr.io/aibrix/v6d/vineyardd:${{ steps.tag.outputs.TAG }}_${{ matrix.platform }}
+          docker tag ghcr.io/aibrix/v6d/vineyardd:alpine-${{ github.sha }}_${{ matrix.platform }} \
+                     ghcr.io/aibrix/v6d/vineyardd:alpine-latest_${{ matrix.platform }}
+          docker tag ghcr.io/aibrix/v6d/vineyardd:alpine-${{ github.sha }}_${{ matrix.platform }} \
+                     ghcr.io/aibrix/v6d/vineyardd:latest_${{ matrix.platform }}
 
-          docker push ghcr.io/v6d-io/v6d/vineyardd:alpine-${{ steps.tag.outputs.TAG }}_${{ matrix.platform }}
-          docker push ghcr.io/v6d-io/v6d/vineyardd:${{ steps.tag.outputs.TAG }}_${{ matrix.platform }}
-          docker push ghcr.io/v6d-io/v6d/vineyardd:alpine-latest_${{ matrix.platform }}
-          docker push ghcr.io/v6d-io/v6d/vineyardd:latest_${{ matrix.platform }}
+          docker push ghcr.io/aibrix/v6d/vineyardd:alpine-${{ steps.tag.outputs.TAG }}_${{ matrix.platform }}
+          docker push ghcr.io/aibrix/v6d/vineyardd:${{ steps.tag.outputs.TAG }}_${{ matrix.platform }}
+          docker push ghcr.io/aibrix/v6d/vineyardd:alpine-latest_${{ matrix.platform }}
+          docker push ghcr.io/aibrix/v6d/vineyardd:latest_${{ matrix.platform }}
 
       - name: Upload CI artifacts
         uses: actions/upload-artifact@v3
@@ -104,7 +104,7 @@ jobs:
   build-vineyardd-manifest:
     needs: [build-vineyardd]
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'aibrix/v6d' || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -122,29 +122,29 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate multi-arch manifest
-        if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'aibrix/v6d' }}
         run: |
           make -C docker/ vineyardd-manifest ALPINE_VERSION=${{ github.sha }}
-          docker manifest push ghcr.io/v6d-io/v6d/vineyardd:alpine-${{ github.sha }}
+          docker manifest push ghcr.io/aibrix/v6d/vineyardd:alpine-${{ github.sha }}
 
       - name: Extract tag name
         id: tag
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Tag and upload manifest for releases
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         run: |
           make -C docker/ vineyardd-manifest ALPINE_VERSION=${{ steps.tag.outputs.TAG }}
-          docker manifest push ghcr.io/v6d-io/v6d/vineyardd:alpine-${{ steps.tag.outputs.TAG }}
+          docker manifest push ghcr.io/aibrix/v6d/vineyardd:alpine-${{ steps.tag.outputs.TAG }}
 
           make -C docker/ vineyardd-manifest ALPINE_MANIFEST_TAG=latest
-          docker manifest push ghcr.io/v6d-io/v6d/vineyardd:latest
+          docker manifest push ghcr.io/aibrix/v6d/vineyardd:latest
 
   build-vineyard-fluid-fuse:
     needs: [build-vineyardd]
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'aibrix/v6d' || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -176,25 +176,25 @@ jobs:
 
       - name: Extract tag name
         id: tag
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Tag and upload docker for releases
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         run: |
-          docker tag ghcr.io/v6d-io/v6d/vineyard-fluid-fuse:${{ github.sha }}_${{ matrix.platform }} \
-                     ghcr.io/v6d-io/v6d/vineyard-fluid-fuse:${{ steps.tag.outputs.TAG }}_${{ matrix.platform }}
-          docker tag ghcr.io/v6d-io/v6d/vineyard-fluid-fuse:${{ github.sha }}_${{ matrix.platform }} \
-                     ghcr.io/v6d-io/v6d/vineyard-fluid-fuse:latest_${{ matrix.platform }}
+          docker tag ghcr.io/aibrix/v6d/vineyard-fluid-fuse:${{ github.sha }}_${{ matrix.platform }} \
+                     ghcr.io/aibrix/v6d/vineyard-fluid-fuse:${{ steps.tag.outputs.TAG }}_${{ matrix.platform }}
+          docker tag ghcr.io/aibrix/v6d/vineyard-fluid-fuse:${{ github.sha }}_${{ matrix.platform }} \
+                     ghcr.io/aibrix/v6d/vineyard-fluid-fuse:latest_${{ matrix.platform }}
 
-          docker push ghcr.io/v6d-io/v6d/vineyard-fluid-fuse:${{ github.sha }}_${{ matrix.platform }}
-          docker push ghcr.io/v6d-io/v6d/vineyard-fluid-fuse:${{ steps.tag.outputs.TAG }}_${{ matrix.platform }}
-          docker push ghcr.io/v6d-io/v6d/vineyard-fluid-fuse:latest_${{ matrix.platform }}
+          docker push ghcr.io/aibrix/v6d/vineyard-fluid-fuse:${{ github.sha }}_${{ matrix.platform }}
+          docker push ghcr.io/aibrix/v6d/vineyard-fluid-fuse:${{ steps.tag.outputs.TAG }}_${{ matrix.platform }}
+          docker push ghcr.io/aibrix/v6d/vineyard-fluid-fuse:latest_${{ matrix.platform }}
 
   build-vineyard-fluid-fuse-manifest:
     needs: [build-vineyard-fluid-fuse]
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'aibrix/v6d' || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -212,28 +212,28 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate multi-arch manifest
-        if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'aibrix/v6d' }}
         run: |
           make -C docker/ vineyard-fluid-fuse-manifest VINEYARD_FLUID_FUSE_VERSION=${{ github.sha }}
-          docker manifest push ghcr.io/v6d-io/v6d/vineyard-fluid-fuse:${{ github.sha }}
+          docker manifest push ghcr.io/aibrix/v6d/vineyard-fluid-fuse:${{ github.sha }}
 
       - name: Extract tag name
         id: tag
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Tag and upload manifest for releases
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         run: |
           make -C docker/ vineyard-fluid-fuse-manifest VINEYARD_FLUID_FUSE_VERSION=${{ steps.tag.outputs.TAG }}
-          docker manifest push ghcr.io/v6d-io/v6d/vineyard-fluid-fuse:${{ steps.tag.outputs.TAG }}
+          docker manifest push ghcr.io/aibrix/v6d/vineyard-fluid-fuse:${{ steps.tag.outputs.TAG }}
 
           make -C docker/ vineyard-fluid-fuse-manifest VINEYARD_FLUID_FUSE_VERSION=latest
-          docker manifest push ghcr.io/v6d-io/v6d/vineyard-fluid-fuse:latest
+          docker manifest push ghcr.io/aibrix/v6d/vineyard-fluid-fuse:latest
 
   build-vineyardctl:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'aibrix/v6d' || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -250,7 +250,7 @@ jobs:
 
       - name: Extract tag name
         id: tag
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Build vineyardctl
@@ -270,7 +270,7 @@ jobs:
 
       - name: Upload vineyardctl to tagged release
         uses: svenstaro/upload-release-action@v2
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ./vineyardctl
@@ -297,7 +297,7 @@ jobs:
   build-bdist-wheels:
     needs: [build-vineyardd, build-vineyardctl]
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'aibrix/v6d' || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -338,7 +338,7 @@ jobs:
 
       - name: Upload wheels to tagged release
         uses: svenstaro/upload-release-action@v2
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: fixed_wheels/*.whl
@@ -356,7 +356,7 @@ jobs:
 
   build-wheels:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'aibrix/v6d' || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -402,7 +402,7 @@ jobs:
             make -C docker/ python-wheel WHEEL_PYTHON=$py WHEEL_VERSION=$WHEEL_VERSION PLATFORM=${{ matrix.platform }}
             docker run --rm \
               -v `pwd`/fixed_wheels:/target \
-              ghcr.io/v6d-io/v6d/vineyard-wheel:${WHEEL_VERSION}_${py}_${{ matrix.platform }} \
+              ghcr.io/aibrix/v6d/vineyard-wheel:${WHEEL_VERSION}_${py}_${{ matrix.platform }} \
               sh -c "cp -r /work/fixed_wheels/* /target/"
           done
           ls -la ./fixed_wheels/
@@ -414,7 +414,7 @@ jobs:
 
       - name: Upload wheels to tagged release
         uses: svenstaro/upload-release-action@v2
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: fixed_wheels/*.whl

--- a/.github/workflows/build-vineyardd-and-wheels-linux.yaml
+++ b/.github/workflows/build-vineyardd-and-wheels-linux.yaml
@@ -176,6 +176,7 @@ jobs:
           VINEYARD_FLUID_FUSE_VERSION: "${{ github.sha }}"
         run: |
           make -C docker/ vineyard-fluid-fuse VINEYARD_FLUID_FUSE_VERSION=$VINEYARD_FLUID_FUSE_VERSION PLATFORM=${{ matrix.platform }}
+          docker push ghcr.io/aibrix/v6d/vineyard-fluid-fuse:${{ github.sha }}_${{ matrix.platform }}
 
       - name: Extract tag name
         id: tag
@@ -190,7 +191,6 @@ jobs:
           docker tag ghcr.io/aibrix/v6d/vineyard-fluid-fuse:${{ github.sha }}_${{ matrix.platform }} \
                      ghcr.io/aibrix/v6d/vineyard-fluid-fuse:latest_${{ matrix.platform }}
 
-          docker push ghcr.io/aibrix/v6d/vineyard-fluid-fuse:${{ github.sha }}_${{ matrix.platform }}
           docker push ghcr.io/aibrix/v6d/vineyard-fluid-fuse:${{ steps.tag.outputs.TAG }}_${{ matrix.platform }}
           docker push ghcr.io/aibrix/v6d/vineyard-fluid-fuse:latest_${{ matrix.platform }}
 

--- a/.github/workflows/build-vineyardd-and-wheels-macos.yaml
+++ b/.github/workflows/build-vineyardd-and-wheels-macos.yaml
@@ -30,7 +30,7 @@ env:
 jobs:
   build-vineyardd:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'aibrix/v6d' || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         os: [macos-11]
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload vineyardd to tagged release
         uses: svenstaro/upload-release-action@v2
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: vineyardd.${{ runner.os }}-generic.${{ github.sha }}.tar.gz
@@ -196,7 +196,7 @@ jobs:
 
   build-vineyardctl:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'aibrix/v6d' || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         os: [macos-11]
@@ -221,7 +221,7 @@ jobs:
 
       - name: Extract tag name
         id: tag
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Build vineyardctl
@@ -238,7 +238,7 @@ jobs:
 
       - name: Upload wheels to tagged release
         uses: svenstaro/upload-release-action@v2
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ./vineyardctl
@@ -267,7 +267,7 @@ jobs:
   build-wheels:
     needs: [build-vineyardd, build-vineyardctl]
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'aibrix/v6d' || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         os: [macos-11]
@@ -461,7 +461,7 @@ jobs:
 
       - name: Upload wheels to tagged release
         uses: svenstaro/upload-release-action@v2
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: fixed_wheels/*.whl

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -34,7 +34,7 @@ env:
 jobs:
   docs:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' }}
+    if: ${{ github.repository == 'aibrix/v6d' }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -105,7 +105,7 @@ jobs:
           bash .github/build-docs.sh
 
       - name: Commit Doc
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'aibrix/v6d' }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/java-ci.yaml
+++ b/.github/workflows/java-ci.yaml
@@ -39,7 +39,7 @@ env:
 jobs:
   ci:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' }}
+    if: ${{ github.repository == 'aibrix/v6d' }}
     strategy:
       matrix:
         os: [ubuntu-20.04]

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   release:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository == 'v6d-io/v6d' }}
+    if: ${{ github.repository == 'aibrix/v6d' }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -49,12 +49,12 @@ jobs:
 
       - name: Extract tag name
         id: tag
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Cut a versioned release
         uses: "marvinpinto/action-automatic-releases@latest"
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: ${{ steps.tag.outputs.TAG }}
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload wheels to tagged release
         uses: svenstaro/upload-release-action@v2
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: v6d-*.*

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-20.04
-    if: ${{ github.repository == 'v6d-io/v6d' }}
+    if: ${{ github.repository == 'aibrix/v6d' }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/vineyard-operator.yaml
+++ b/.github/workflows/vineyard-operator.yaml
@@ -43,16 +43,16 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REGISTRY: ghcr.io/v6d-io/v6d
+  REGISTRY: ghcr.io/aibrix/v6d
   IMG: vineyardcloudnative/vineyard-operator:latest
-  NIGHTLY_IMG: ghcr.io/v6d-io/v6d/vineyard-operator:nightly
-  LATEST_IMG: ghcr.io/v6d-io/v6d/vineyard-operator:latest
+  NIGHTLY_IMG: ghcr.io/aibrix/v6d/vineyard-operator:nightly
+  LATEST_IMG: ghcr.io/aibrix/v6d/vineyard-operator:latest
   KUBECONFIG: /tmp/e2e-k8s.config
 
 jobs:
   ci:
     runs-on: ubuntu-20.04
-    if: ${{ github.repository == 'v6d-io/v6d' }}
+    if: ${{ github.repository == 'aibrix/v6d' }}
     strategy:
       fail-fast: false
       matrix:
@@ -143,20 +143,20 @@ jobs:
         run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Set up qemu
-        if: ${{ matrix.job == 'release' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ matrix.job == 'release' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        if: ${{ matrix.job == 'release' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ matrix.job == 'release' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         uses: docker/setup-buildx-action@v2
 
       - name: Upload latest docker image of vineyard-operator
-        if: ${{ matrix.job == 'release' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        if: ${{ matrix.job == 'release' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'aibrix/v6d' }}
         run: |
           # pre-publish to ghcr.io to avoid the "no basic auth credentials" error
-          export IMG=ghcr.io/v6d-io/v6d/vineyard-operator:${{ steps.tag.outputs.TAG }}
+          export IMG=ghcr.io/aibrix/v6d/vineyard-operator:${{ steps.tag.outputs.TAG }}
           make -C k8s docker-build-push-multi-arch REGISTRY=${{ env.REGISTRY }} VERSION=${{ steps.tag.outputs.TAG }}
-          export IMG=ghcr.io/v6d-io/v6d/vineyard-operator:latest
+          export IMG=ghcr.io/aibrix/v6d/vineyard-operator:latest
           make -C k8s docker-build-push-multi-arch REGISTRY=${{ env.REGISTRY }} VERSION=latest
 
       - name: Generate the python and vineyardd image for tests
@@ -368,4 +368,4 @@ jobs:
               ;;
           esac
 
-          echo "::notice:: ${{ matrix.job }}: https://www.stoat.dev/file-viewer?root=https://v6d-io--v6d--$short_sha--e2e-tests-$signed_url_key.stoat.page"
+          echo "::notice:: ${{ matrix.job }}: https://www.stoat.dev/file-viewer?root=https://aibrix--v6d--$short_sha--e2e-tests-$signed_url_key.stoat.page"

--- a/docker/Dockerfile.vineyard-python-dev
+++ b/docker/Dockerfile.vineyard-python-dev
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # build vineyard-python-dev
-FROM ghcr.io/v6d-io/v6d/vineyard-manylinux2014:20240803 as wheel
+FROM ghcr.io/aibrix/v6d/vineyard-manylinux2014:20240803 as wheel
 
 ENV python=cp310-cp310
 

--- a/docker/Dockerfile.vineyardd
+++ b/docker/Dockerfile.vineyardd
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/v6d-io/v6d/vineyardd-alpine-builder:builder-latest as builder
+FROM ghcr.io/aibrix/v6d/vineyardd-alpine-builder:builder-latest as builder
 
 RUN export arch="$PLATFORM" && \
     export arch="${arch/x86_64/amd64}" && \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
-REGISTRY 					:= ghcr.io/v6d-io/v6d
+REGISTRY 					:= ghcr.io/aibrix/v6d
 RELEASE_REGISTRY			:= docker.io/vineyardcloudnative
 
 # can be: x86_64, aarch64
@@ -67,7 +67,7 @@ vineyardd:
 	docker buildx build ../ \
 		--progress=$(BUILD_PROGRESS) \
 		--file ./Dockerfile.vineyardd \
-		-t ghcr.io/v6d-io/v6d/vineyardd:$(ALPINE_TAG) \
+		-t ghcr.io/aibrix/v6d/vineyardd:$(ALPINE_TAG) \
 		--load \
 		--platform linux/$(ARCH)
 .PHONY: vineyardd

--- a/docker/pypa/Dockerfile.manylinux1
+++ b/docker/pypa/Dockerfile.manylinux1
@@ -28,7 +28,7 @@ RUN mv /etc/yum.repos.d/CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo.backu
     yum -y update && \
     yum -y install devtoolset-10-libatomic-devel libtool
 
-# target: ghcr.io/v6d-io/v6d/vineyard-manylinux2014:20240218_$PLATFORM
+# target: ghcr.io/aibrix/v6d/vineyard-manylinux2014:20240218_$PLATFORM
 
 # Not sure why bundled cmake(3.28.0) in pipx doesn't work
 #

--- a/docker/pypa/Dockerfile.manylinux1-wheel
+++ b/docker/pypa/Dockerfile.manylinux1-wheel
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 ARG BASE_VERSION=latest
-FROM ghcr.io/v6d-io/v6d/vineyard-manylinux2014:$BASE_VERSION as builder
+FROM ghcr.io/aibrix/v6d/vineyard-manylinux2014:$BASE_VERSION as builder
 
-# target: ghcr.io/v6d-io/v6d/vineyard-wheel
+# target: ghcr.io/aibrix/v6d/vineyard-wheel
 
 # specify python version:
 #   - cp36-cp36m

--- a/docker/vineyard-fluid-fuse/Dockerfile
+++ b/docker/vineyard-fluid-fuse/Dockerfile
@@ -1,6 +1,6 @@
 ARG PLATFORM=x86_64
-FROM ghcr.io/v6d-io/v6d/vineyardd:alpine-latest_x86_64 as base_x86_64
-FROM ghcr.io/v6d-io/v6d/vineyardd:alpine-latest_aarch64  as base_aarch64
+FROM ghcr.io/aibrix/v6d/vineyardd:alpine-latest_x86_64 as base_x86_64
+FROM ghcr.io/aibrix/v6d/vineyardd:alpine-latest_aarch64  as base_aarch64
 
 FROM base_$PLATFORM
 

--- a/docker/vineyardd/Dockerfile.alpine-builder
+++ b/docker/vineyardd/Dockerfile.alpine-builder
@@ -20,7 +20,7 @@ FROM arm64v8/centos:7 as base_aarch64
 ARG PLATFORM
 FROM base_$PLATFORM
 
-# target: ghcr.io/v6d-io/v6d/vineyardd-alpine-builder:builder-latest_$PLATFORM
+# target: ghcr.io/aibrix/v6d/vineyardd-alpine-builder:builder-latest_$PLATFORM
 
 SHELL ["/bin/bash", "-c"]
 

--- a/k8s/test/e2e/Dockerfile
+++ b/k8s/test/e2e/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/v6d-io/v6d/vineyard-python-dev:latest
+FROM ghcr.io/aibrix/v6d/vineyard-python-dev:latest
 
 WORKDIR /
 

--- a/k8s/test/e2e/Makefile
+++ b/k8s/test/e2e/Makefile
@@ -30,7 +30,7 @@ load-vineyardd-image:
 .PHONY: load-vineyardd-image
 
 load-vineyard-python-dev-image:
-	@docker tag ghcr.io/v6d-io/v6d/vineyard-python-dev:latest localhost:5001/vineyard-python-dev:latest
+	@docker tag ghcr.io/aibrix/v6d/vineyard-python-dev:latest localhost:5001/vineyard-python-dev:latest
 	@docker push localhost:5001/vineyard-python-dev:latest
 
 load-vineyard-operator-image:
@@ -52,10 +52,10 @@ prepare-e2e-test:
 build-base-images:
 	@echo "Building the python dev image"
 	@make -C ${ROOT_DIR}/docker build-python-dev
-	@docker tag ghcr.io/v6d-io/v6d/vineyard-python-dev:latest_x86_64 ghcr.io/v6d-io/v6d/vineyard-python-dev:latest
+	@docker tag ghcr.io/aibrix/v6d/vineyard-python-dev:latest_x86_64 ghcr.io/aibrix/v6d/vineyard-python-dev:latest
 	@echo "Building the vineyardd image"
 	@make -C ${ROOT_DIR}/docker vineyardd
-	@docker tag ghcr.io/v6d-io/v6d/vineyardd:alpine-latest_x86_64 vineyardcloudnative/vineyardd:latest
+	@docker tag ghcr.io/aibrix/v6d/vineyardd:alpine-latest_x86_64 vineyardcloudnative/vineyardd:latest
 
 # Build a 4-nodes(1 master and 3 workers) kind cluster with local registry
 build-local-cluster:

--- a/misc/release-docker.sh
+++ b/misc/release-docker.sh
@@ -16,18 +16,18 @@ fi
 
 # vineyardd
 for tag in ${version} latest alpine-${version} alpine-latest; do
-    regctl image copy -v info ghcr.io/v6d-io/v6d/vineyardd:alpine-${version} \
+    regctl image copy -v info ghcr.io/aibrix/v6d/vineyardd:alpine-${version} \
                               vineyardcloudnative/vineyardd:${tag}
 done
 
 # vineyard-operator
 for tag in ${version} latest; do
-    regctl image copy -v info ghcr.io/v6d-io/v6d/vineyard-operator:${version} \
+    regctl image copy -v info ghcr.io/aibrix/v6d/vineyard-operator:${version} \
                               vineyardcloudnative/vineyard-operator:${tag}
 done
 
 # vineyard-fluid-fuse
 for tag in ${version} latest; do
-    regctl image copy -v info ghcr.io/v6d-io/v6d/vineyard-fluid-fuse:${version} \
+    regctl image copy -v info ghcr.io/aibrix/v6d/vineyard-fluid-fuse:${version} \
                               vineyardcloudnative/vineyard-fluid-fuse:${tag}
 done

--- a/misc/release-wheels.sh
+++ b/misc/release-wheels.sh
@@ -15,7 +15,7 @@ mkdir -p wheels/$version
 
 # download wheels from github artifacts
 pushd wheels/$version
-curl -s https://api.github.com/repos/v6d-io/v6d/releases/tags/$version | grep "browser_download_url.*whl" | cut -d : -f 2,3 | tr -d \" | wget -qi -
+curl -s https://api.github.com/repos/aibrix/v6d/releases/tags/$version | grep "browser_download_url.*whl" | cut -d : -f 2,3 | tr -d \" | wget -qi -
 popd
 
 twine check ./wheels/$version/*.whl

--- a/modules/llm-cache/ds/kv_cache_block.cc
+++ b/modules/llm-cache/ds/kv_cache_block.cc
@@ -125,14 +125,18 @@ KVCacheBlockBuilder::KVCacheBlockBuilder(
   dst_buffers.reserve(this->layer * 2);
   src_buffers.reserve(this->layer * 2);
   for (int currentLayer = 0; currentLayer < this->layer; currentLayer++) {
-    dst_buffers.push_back(this->keyStateTensorBuilderList[currentLayer]->data());
-    dst_buffers.push_back(this->valueStateTensorBuilderList[currentLayer]->data());
-    src_buffers.push_back(kvCacheBlock->keyStateTensorList[currentLayer]->data());
-    src_buffers.push_back(kvCacheBlock->valueStateTensorList[currentLayer]->data());
+    dst_buffers.push_back(
+        this->keyStateTensorBuilderList[currentLayer]->data());
+    dst_buffers.push_back(
+        this->valueStateTensorBuilderList[currentLayer]->data());
+    src_buffers.push_back(
+        kvCacheBlock->keyStateTensorList[currentLayer]->data());
+    src_buffers.push_back(
+        kvCacheBlock->valueStateTensorList[currentLayer]->data());
   }
 
   vineyard::memory::concurrent_memcpy_n(dst_buffers, src_buffers,
-                                        (int64_t) (blockSize) *tensorNBytes);
+                                        (int64_t)(blockSize) *tensorNBytes);
 }
 
 Status KVCacheBlockBuilder::Make(Client& client, TreeData* treeData,
@@ -160,7 +164,7 @@ Status KVCacheBlockBuilder::Query(
                    "Index out of range: " + std::to_string(index));
   RETURN_ON_ASSERT(static_cast<int>(kvState.size()) == this->layer,
                    "The size of kvState is not equal to layer");
-  
+
   if (kvState[0].first.data == nullptr) {
     for (int currentLayer = 0; currentLayer < this->layer; currentLayer++) {
       LLMKV& keyState = kvState[currentLayer].first;

--- a/modules/llm-cache/tests/k8s-test/Dockerfile.worker
+++ b/modules/llm-cache/tests/k8s-test/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM ghcr.io/v6d-io/v6d/vineyard-python-dev:latest_x86_64 as builder
+FROM ghcr.io/aibrix/v6d/vineyard-python-dev:latest_x86_64 as builder
 
 FROM python:3.10
 

--- a/modules/llm-cache/tests/kv_cache_test.cc
+++ b/modules/llm-cache/tests/kv_cache_test.cc
@@ -195,11 +195,11 @@ void inference(std::shared_ptr<KVCacheManager>& kv_cache_manager,
   LOG(INFO) << "kv_state_to_query size: " << kv_state_to_query.size()
             << ", layer" << layer << ", tensorNBytes" << tensorNBytes;
   for (int i = 0; i < tokens.size(); i++) {
-      kv_state_to_query.clear();
-      for (int currentLayer = 0; currentLayer < layer; currentLayer++) {
-        kv_state_to_query.emplace_back(LLMKV{nullptr, 0}, LLMKV{nullptr, 0});
-      }
-      kv_state_to_query_list.emplace_back(kv_state_to_query);
+    kv_state_to_query.clear();
+    for (int currentLayer = 0; currentLayer < layer; currentLayer++) {
+      kv_state_to_query.emplace_back(LLMKV{nullptr, 0}, LLMKV{nullptr, 0});
+    }
+    kv_state_to_query_list.emplace_back(kv_state_to_query);
   }
   size_t matched = 0;
   Status result = kv_cache_manager->Query(inference_tokens, tokens,
@@ -230,12 +230,12 @@ void threadFunc(std::string socket) {
   sleep(5);
 
   for (size_t i = 0; i < tokens_list.size(); i++) {
-      size_t half_index = tokens_list[i].size() / 2;
-      std::vector<int> prefix(tokens_list[i].begin(),
-                              tokens_list[i].begin() + half_index);
-      std::vector<int> tokens_list_rest(tokens_list[i].begin() + half_index,
-                                        tokens_list[i].end());
-      inference(manager, prefix, tokens_list_rest);
+    size_t half_index = tokens_list[i].size() / 2;
+    std::vector<int> prefix(tokens_list[i].begin(),
+                            tokens_list[i].begin() + half_index);
+    std::vector<int> tokens_list_rest(tokens_list[i].begin() + half_index,
+                                      tokens_list[i].end());
+    inference(manager, prefix, tokens_list_rest);
   }
 
   LOG(INFO) << "inference end";

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.package]
 version = "0.18.1"
 homepage = "https://v6d.io"
-repository = "https://github.com/v6d-io/v6d.git"
+repository = "https://github.com/aibrix/v6d.git"
 authors = ["Vineyard <vineyard@alibaba-inc.com>"]
 license = "Apache-2.0"
 keywords = ["vineyard"]

--- a/setup.py
+++ b/setup.py
@@ -281,7 +281,7 @@ setup(
     ],
     project_urls={
         "Documentation": "https://v6d.io",
-        "Source": "https://github.com/v6d-io/v6d",
-        "Tracker": "https://github.com/v6d-io/v6d/issues",
+        "Source": "https://github.com/aibrix/v6d",
+        "Tracker": "https://github.com/aibrix/v6d/issues",
     },
 )

--- a/setup_airflow.py
+++ b/setup_airflow.py
@@ -105,7 +105,7 @@ setup(
     ],
     project_urls={
         'Documentation': 'https://v6d.io',
-        'Source': 'https://github.com/v6d-io/v6d',
-        'Tracker': 'https://github.com/v6d-io/v6d/issues',
+        'Source': 'https://github.com/aibrix/v6d',
+        'Tracker': 'https://github.com/aibrix/v6d/issues',
     },
 )

--- a/setup_bdist.py
+++ b/setup_bdist.py
@@ -119,7 +119,7 @@ setup(
     ],
     project_urls={
         "Documentation": "https://v6d.io",
-        "Source": "https://github.com/v6d-io/v6d",
-        "Tracker": "https://github.com/v6d-io/v6d/issues",
+        "Source": "https://github.com/aibrix/v6d",
+        "Tracker": "https://github.com/aibrix/v6d/issues",
     },
 )

--- a/setup_dask.py
+++ b/setup_dask.py
@@ -108,7 +108,7 @@ setup(
     ],
     project_urls={
         'Documentation': 'https://v6d.io',
-        'Source': 'https://github.com/v6d-io/v6d',
-        'Tracker': 'https://github.com/v6d-io/v6d/issues',
+        'Source': 'https://github.com/aibrix/v6d',
+        'Tracker': 'https://github.com/aibrix/v6d/issues',
     },
 )

--- a/setup_io.py
+++ b/setup_io.py
@@ -140,7 +140,7 @@ setup(
     ],
     project_urls={
         'Documentation': 'https://v6d.io',
-        'Source': 'https://github.com/v6d-io/v6d',
-        'Tracker': 'https://github.com/v6d-io/v6d/issues',
+        'Source': 'https://github.com/aibrix/v6d',
+        'Tracker': 'https://github.com/aibrix/v6d/issues',
     },
 )

--- a/setup_kedro.py
+++ b/setup_kedro.py
@@ -114,7 +114,7 @@ setup(
     ],
     project_urls={
         'Documentation': 'https://v6d.io',
-        'Source': 'https://github.com/v6d-io/v6d',
-        'Tracker': 'https://github.com/v6d-io/v6d/issues',
+        'Source': 'https://github.com/aibrix/v6d',
+        'Tracker': 'https://github.com/aibrix/v6d/issues',
     },
 )

--- a/setup_llm.py
+++ b/setup_llm.py
@@ -119,7 +119,7 @@ setup(
     ],
     project_urls={
         'Documentation': 'https://v6d.io',
-        'Source': 'https://github.com/v6d-io/v6d',
-        'Tracker': 'https://github.com/v6d-io/v6d/issues',
+        'Source': 'https://github.com/aibrix/v6d',
+        'Tracker': 'https://github.com/aibrix/v6d/issues',
     },
 )

--- a/setup_ml.py
+++ b/setup_ml.py
@@ -101,7 +101,7 @@ setup(
     ],
     project_urls={
         'Documentation': 'https://v6d.io',
-        'Source': 'https://github.com/v6d-io/v6d',
-        'Tracker': 'https://github.com/v6d-io/v6d/issues',
+        'Source': 'https://github.com/aibrix/v6d',
+        'Tracker': 'https://github.com/aibrix/v6d/issues',
     },
 )

--- a/setup_pyspark.py
+++ b/setup_pyspark.py
@@ -108,7 +108,7 @@ setup(
     ],
     project_urls={
         'Documentation': 'https://v6d.io',
-        'Source': 'https://github.com/v6d-io/v6d',
-        'Tracker': 'https://github.com/v6d-io/v6d/issues',
+        'Source': 'https://github.com/aibrix/v6d',
+        'Tracker': 'https://github.com/aibrix/v6d/issues',
     },
 )

--- a/setup_ray.py
+++ b/setup_ray.py
@@ -108,7 +108,7 @@ setup(
     ],
     project_urls={
         'Documentation': 'https://v6d.io',
-        'Source': 'https://github.com/v6d-io/v6d',
-        'Tracker': 'https://github.com/v6d-io/v6d/issues',
+        'Source': 'https://github.com/aibrix/v6d',
+        'Tracker': 'https://github.com/aibrix/v6d/issues',
     },
 )

--- a/test/concurrent_memcpy_test.cc
+++ b/test/concurrent_memcpy_test.cc
@@ -50,167 +50,168 @@ void testing_memcpy(const size_t size) {
 }
 
 void test_concurrent_memcpy_n_basic() {
-    std::vector<const void*> src_buffers;
-    std::vector<void*> dst_buffers;
-    size_t buffer_size = 1 * 1024 * 1024;  // 1MB per buffer
+  std::vector<const void*> src_buffers;
+  std::vector<void*> dst_buffers;
+  size_t buffer_size = 1 * 1024 * 1024;  // 1MB per buffer
 
-    char* src1 = new char[buffer_size];
-    char* dst1 = new char[buffer_size];
+  char* src1 = new char[buffer_size];
+  char* dst1 = new char[buffer_size];
 
-    std::memset(src1, 'A', buffer_size);
+  std::memset(src1, 'A', buffer_size);
 
-    src_buffers.push_back(src1);
-    dst_buffers.push_back(dst1);
+  src_buffers.push_back(src1);
+  dst_buffers.push_back(dst1);
 
-    size_t concurrency_level = 1;
+  size_t concurrency_level = 1;
 
-    vineyard::memory::concurrent_memcpy_n(dst_buffers, src_buffers, buffer_size,
-                                          concurrency_level);
+  vineyard::memory::concurrent_memcpy_n(dst_buffers, src_buffers, buffer_size,
+                                        concurrency_level);
 
-    assert(std::memcmp(dst1, src1, buffer_size) == 0);
+  assert(std::memcmp(dst1, src1, buffer_size) == 0);
 
-    delete[] src1;
-    delete[] dst1;
+  delete[] src1;
+  delete[] dst1;
 
-    LOG(INFO) << "Passed concurrent_memcpy_n test: basic single buffer copy";
+  LOG(INFO) << "Passed concurrent_memcpy_n test: basic single buffer copy";
 }
 
 void test_concurrent_memcpy_n_multiple_buffers() {
-    std::vector<const void*> src_buffers;
-    std::vector<void*> dst_buffers;
-    size_t buffer_size = 2 * 1024 * 1024;  // 2MB per buffer
+  std::vector<const void*> src_buffers;
+  std::vector<void*> dst_buffers;
+  size_t buffer_size = 2 * 1024 * 1024;  // 2MB per buffer
 
-    char* src1 = new char[buffer_size];
-    char* src2 = new char[buffer_size];
-    char* dst1 = new char[buffer_size];
-    char* dst2 = new char[buffer_size];
+  char* src1 = new char[buffer_size];
+  char* src2 = new char[buffer_size];
+  char* dst1 = new char[buffer_size];
+  char* dst2 = new char[buffer_size];
 
-    std::memset(src1, 'A', buffer_size);
-    std::memset(src2, 'B', buffer_size);
+  std::memset(src1, 'A', buffer_size);
+  std::memset(src2, 'B', buffer_size);
 
-    src_buffers.push_back(src1);
-    src_buffers.push_back(src2);
-    dst_buffers.push_back(dst1);
-    dst_buffers.push_back(dst2);
+  src_buffers.push_back(src1);
+  src_buffers.push_back(src2);
+  dst_buffers.push_back(dst1);
+  dst_buffers.push_back(dst2);
 
-    size_t concurrency_level = 2;
+  size_t concurrency_level = 2;
 
-    vineyard::memory::concurrent_memcpy_n(dst_buffers, src_buffers, buffer_size,
-                                          concurrency_level);
+  vineyard::memory::concurrent_memcpy_n(dst_buffers, src_buffers, buffer_size,
+                                        concurrency_level);
 
-    assert(std::memcmp(dst1, src1, buffer_size) == 0);
-    assert(std::memcmp(dst2, src2, buffer_size) == 0);
+  assert(std::memcmp(dst1, src1, buffer_size) == 0);
+  assert(std::memcmp(dst2, src2, buffer_size) == 0);
 
-    delete[] src1;
-    delete[] src2;
-    delete[] dst1;
-    delete[] dst2;
+  delete[] src1;
+  delete[] src2;
+  delete[] dst1;
+  delete[] dst2;
 
-    LOG(INFO) << "Passed concurrent_memcpy_n test: multiple buffer copy";
+  LOG(INFO) << "Passed concurrent_memcpy_n test: multiple buffer copy";
 }
 
 void test_concurrent_memcpy_n_with_small_buffers() {
-    std::vector<const void*> src_buffers;
-    std::vector<void*> dst_buffers;
-    size_t buffer_size = 1 * 1024 * 1024;  // 1MB per buffer
+  std::vector<const void*> src_buffers;
+  std::vector<void*> dst_buffers;
+  size_t buffer_size = 1 * 1024 * 1024;  // 1MB per buffer
 
-    char* src1 = new char[buffer_size];
-    char* src2 = new char[buffer_size];
-    char* dst1 = new char[buffer_size];
-    char* dst2 = new char[buffer_size];
+  char* src1 = new char[buffer_size];
+  char* src2 = new char[buffer_size];
+  char* dst1 = new char[buffer_size];
+  char* dst2 = new char[buffer_size];
 
-    std::memset(src1, 'A', buffer_size);
-    std::memset(src2, 'B', buffer_size);
+  std::memset(src1, 'A', buffer_size);
+  std::memset(src2, 'B', buffer_size);
 
-    src_buffers.push_back(src1);
-    src_buffers.push_back(src2);
-    dst_buffers.push_back(dst1);
-    dst_buffers.push_back(dst2);
+  src_buffers.push_back(src1);
+  src_buffers.push_back(src2);
+  dst_buffers.push_back(dst1);
+  dst_buffers.push_back(dst2);
 
-    size_t concurrency_level = 2;
+  size_t concurrency_level = 2;
 
-    vineyard::memory::concurrent_memcpy_n(dst_buffers, src_buffers, buffer_size,
-                                          concurrency_level);
+  vineyard::memory::concurrent_memcpy_n(dst_buffers, src_buffers, buffer_size,
+                                        concurrency_level);
 
-    assert(std::memcmp(dst1, src1, buffer_size) == 0);
-    assert(std::memcmp(dst2, src2, buffer_size) == 0);
+  assert(std::memcmp(dst1, src1, buffer_size) == 0);
+  assert(std::memcmp(dst2, src2, buffer_size) == 0);
 
-    delete[] src1;
-    delete[] src2;
-    delete[] dst1;
-    delete[] dst2;
+  delete[] src1;
+  delete[] src2;
+  delete[] dst1;
+  delete[] dst2;
 
-    LOG(INFO) << "Passed concurrent_memcpy_n test: small buffers";
+  LOG(INFO) << "Passed concurrent_memcpy_n test: small buffers";
 }
 
 void test_concurrent_memcpy_n_large_buffer() {
-    std::vector<const void*> src_buffers;
-    std::vector<void*> dst_buffers;
-    size_t buffer_size = 8 * 1024 * 1024;  // 8MB per buffer
+  std::vector<const void*> src_buffers;
+  std::vector<void*> dst_buffers;
+  size_t buffer_size = 8 * 1024 * 1024;  // 8MB per buffer
 
-    char* src1 = new char[buffer_size];
-    char* dst1 = new char[buffer_size];
+  char* src1 = new char[buffer_size];
+  char* dst1 = new char[buffer_size];
 
-    std::memset(src1, 'A', buffer_size);
+  std::memset(src1, 'A', buffer_size);
 
-    src_buffers.push_back(src1);
-    dst_buffers.push_back(dst1);
+  src_buffers.push_back(src1);
+  dst_buffers.push_back(dst1);
 
-    size_t concurrency_level = 2;  // Expect splitting across threads
+  size_t concurrency_level = 2;  // Expect splitting across threads
 
-    vineyard::memory::concurrent_memcpy_n(dst_buffers, src_buffers, buffer_size,
-                                          concurrency_level);
+  vineyard::memory::concurrent_memcpy_n(dst_buffers, src_buffers, buffer_size,
+                                        concurrency_level);
 
-    assert(std::memcmp(dst1, src1, buffer_size) == 0);
+  assert(std::memcmp(dst1, src1, buffer_size) == 0);
 
-    delete[] src1;
-    delete[] dst1;
+  delete[] src1;
+  delete[] dst1;
 
-    LOG(INFO)
-        << "Passed concurrent_memcpy_n test: large buffer copy with splitting";
+  LOG(INFO)
+      << "Passed concurrent_memcpy_n test: large buffer copy with splitting";
 }
 
 void test_concurrent_memcpy_n_with_uneven_distribution() {
-    std::vector<const void*> src_buffers;
-    std::vector<void*> dst_buffers;
-    size_t buffer_size = 3 * 1024 * 1024;  // 3MB per buffer
+  std::vector<const void*> src_buffers;
+  std::vector<void*> dst_buffers;
+  size_t buffer_size = 3 * 1024 * 1024;  // 3MB per buffer
 
-    char* src1 = new char[buffer_size];
-    char* src2 = new char[buffer_size];
-    char* src3 = new char[buffer_size];
-    char* dst1 = new char[buffer_size];
-    char* dst2 = new char[buffer_size];
-    char* dst3 = new char[buffer_size];
+  char* src1 = new char[buffer_size];
+  char* src2 = new char[buffer_size];
+  char* src3 = new char[buffer_size];
+  char* dst1 = new char[buffer_size];
+  char* dst2 = new char[buffer_size];
+  char* dst3 = new char[buffer_size];
 
-    std::memset(src1, 'A', buffer_size);
-    std::memset(src2, 'B', buffer_size);
-    std::memset(src3, 'C', buffer_size);
+  std::memset(src1, 'A', buffer_size);
+  std::memset(src2, 'B', buffer_size);
+  std::memset(src3, 'C', buffer_size);
 
-    src_buffers.push_back(src1);
-    src_buffers.push_back(src2);
-    src_buffers.push_back(src3);
-    dst_buffers.push_back(dst1);
-    dst_buffers.push_back(dst2);
-    dst_buffers.push_back(dst3);
+  src_buffers.push_back(src1);
+  src_buffers.push_back(src2);
+  src_buffers.push_back(src3);
+  dst_buffers.push_back(dst1);
+  dst_buffers.push_back(dst2);
+  dst_buffers.push_back(dst3);
 
-    size_t concurrency_level = 2;  // Results in uneven distribution across threads
+  size_t concurrency_level =
+      2;  // Results in uneven distribution across threads
 
-    vineyard::memory::concurrent_memcpy_n(dst_buffers, src_buffers, buffer_size,
-                                          concurrency_level);
+  vineyard::memory::concurrent_memcpy_n(dst_buffers, src_buffers, buffer_size,
+                                        concurrency_level);
 
-    assert(std::memcmp(dst1, src1, buffer_size) == 0);
-    assert(std::memcmp(dst2, src2, buffer_size) == 0);
-    assert(std::memcmp(dst3, src3, buffer_size) == 0);
+  assert(std::memcmp(dst1, src1, buffer_size) == 0);
+  assert(std::memcmp(dst2, src2, buffer_size) == 0);
+  assert(std::memcmp(dst3, src3, buffer_size) == 0);
 
-    delete[] src1;
-    delete[] src2;
-    delete[] src3;
-    delete[] dst1;
-    delete[] dst2;
-    delete[] dst3;
+  delete[] src1;
+  delete[] src2;
+  delete[] src3;
+  delete[] dst1;
+  delete[] dst2;
+  delete[] dst3;
 
-    LOG(INFO) << "Passed concurrent_memcpy_n test: uneven distribution with "
-                 "larger buffers";
+  LOG(INFO) << "Passed concurrent_memcpy_n test: uneven distribution with "
+               "larger buffers";
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
- makes necessary renaming
- fixes format issues of cpp code
  - fixes 678ef43 ("v1/api: support query w/ existing buffer")
  - fixes a1dbac7 ("feat: query interface ext")
- adds pkg write permission for workflows pushing pkgs
- fixes fluid fuse image build procedure
  - fixes 78e236e ("Support to start vineyardd in vineyard fluid fuse.")

Note: vineyard operator CI workflow is not enabled and will only be enabled if needed in the future.