### PR TITLE
feat: add lock timeout for v1 APIs

### DIFF
--- a/modules/llm-cache/README.md
+++ b/modules/llm-cache/README.md
@@ -159,6 +159,7 @@ vineyard_cache_config = VineyardCacheConfig(
     socket="/tmp/vineyard_test.sock"
     block_size=5,
     sync_interval=3,
+    cache_access_lock_timeout_ms=10,
     llm_cache_sync_lock="llmCacheSyncLock",
     llm_cache_object_name="llm_cache_object",
     llm_ref_cnt_object_name="llm_refcnt_object",

--- a/modules/llm-cache/ds/config.h
+++ b/modules/llm-cache/ds/config.h
@@ -31,18 +31,21 @@ struct KVCacheConfig {
 struct VineyardCacheConfig : public KVCacheConfig {
   int blockSize;
   int syncInterval;
+  int cacheAccessLockTimeoutMs;  // in milliseconds
   std::string llmCacheSyncLock;
   std::string llmCacheObjectName;
   std::string llmRefcntObjectName;
 
   VineyardCacheConfig(int tensorByte = 10, int cacheCapacity = 10,
                       int layer = 1, int blockSize = 5, int syncInterval = 3,
+                      int cacheAccessLockTimeoutMs = 10,
                       std::string llmCacheSyncLock = "llmCacheSyncLock",
                       std::string llmCacheObjectName = "llm_cache_object",
                       std::string llmRefcntObjectName = "llm_refcnt_object")
       : KVCacheConfig{tensorByte, cacheCapacity, layer},
         blockSize(blockSize),
         syncInterval(syncInterval),
+        cacheAccessLockTimeoutMs(cacheAccessLockTimeoutMs),
         llmCacheSyncLock(llmCacheSyncLock),
         llmCacheObjectName(llmCacheObjectName),
         llmRefcntObjectName(llmRefcntObjectName) {}

--- a/modules/llm-cache/ds/kv_cache_manager.cc
+++ b/modules/llm-cache/ds/kv_cache_manager.cc
@@ -56,8 +56,8 @@ Status KVCacheManager::Make(Client& client,
   VINEYARD_CHECK_OK(blob_storage->Make(
       client, blob_storage, config.tensorByte, config.cacheCapacity,
       config.layer, config.blockSize, config.syncInterval,
-      config.llmCacheSyncLock, config.llmCacheObjectName,
-      config.llmRefcntObjectName));
+      config.cacheAccessLockTimeoutMs, config.llmCacheSyncLock,
+      config.llmCacheObjectName, config.llmRefcntObjectName));
   manager = std::make_shared<KVCacheManager>(blob_storage);
   manager->config = std::make_shared<VineyardCacheConfig>(config);
   return Status::OK();

--- a/modules/llm-cache/storage/blob_storage.h
+++ b/modules/llm-cache/storage/blob_storage.h
@@ -44,8 +44,9 @@ class BlobStorage : public IStorage {
   std::string llmCacheObjectName;
   std::string llmRefcntObjectName;
   std::thread syncThread;
-  std::mutex cacheAccessMutex;
+  std::timed_mutex cacheAccessMutex;
   int syncInterval;
+  int cacheAccessLockTimeoutMs;
   bool exitFlag = false;
   std::condition_variable cv;
   std::mutex exitMutex;
@@ -53,13 +54,14 @@ class BlobStorage : public IStorage {
 
  public:
   BlobStorage(Client& client, std::shared_ptr<KVCacheBuilder>& cache,
-              int syncInterval, std::string& llmCacheSyncLock,
-              std::string& llmCacheObjectName,
+              int syncInterval, int cacheAccessLockTimeoutMs,
+              std::string& llmCacheSyncLock, std::string& llmCacheObjectName,
               std::string& llmRefcntObjectName);
 
   static Status Make(Client& client, std::shared_ptr<BlobStorage>& storage,
                      int tensorNBytes = 10, int cacheCapacity = 10,
                      int layer = 1, int blockSize = 5, int syncInterval = 3,
+                     int cacheAccessLockTimeoutMs = 10,
                      std::string llmCacheSyncLock = "llmCacheSyncLock",
                      std::string llmCacheObjectName = "llm_cache_object",
                      std::string llmRefcntObjectName = "llm_refcnt_object");

--- a/modules/llm-cache/tests/kv_cache_test.cc
+++ b/modules/llm-cache/tests/kv_cache_test.cc
@@ -321,7 +321,7 @@ int main(int argc, char** argv) {
             << ", block_size: " << block_size << " and use " << client_num
             << " client.";
 
-  config = VineyardCacheConfig(tensorNBytes, capacity, layer, block_size, 3,
+  config = VineyardCacheConfig(tensorNBytes, capacity, layer, block_size, 3, 10,
                                llmCacheSyncLock, llmCacheObjectName,
                                llmRefcntObjectName);
 

--- a/modules/llm-cache/tests/refcnt_map_test.cc
+++ b/modules/llm-cache/tests/refcnt_map_test.cc
@@ -247,7 +247,7 @@ void threadFunc(std::string socket, int threadId) {
   std::shared_ptr<BlobStorage> blob_storage;
   VINEYARD_CHECK_OK(BlobStorage::Make(
       client[threadId], blob_storage, tensorNBytes, capacity, layer, block_size,
-      3, llmCacheSyncLock, llmCacheObjectName, llmRefcntObjectName));
+      3, 10, llmCacheSyncLock, llmCacheObjectName, llmRefcntObjectName));
   blob_storages.push_back(blob_storage);
   kv_cache_manager = std::make_shared<KVCacheManager>(blob_storage);
   kv_cache_managers.push_back(kv_cache_manager);

--- a/python/vineyard/llm/cache.cc
+++ b/python/vineyard/llm/cache.cc
@@ -68,13 +68,15 @@ PYBIND11_MODULE(_llm_C, m) {
                                                               "KVCacheManager")
       .def(py::init([](py::object ipc_client, int tensor_nbytes,
                        int cache_capacity, int layer, int block_size,
-                       int sync_interval, std::string llm_cache_sync_lock,
+                       int sync_interval, int cache_access_lock_timeout_ms,
+                       std::string llm_cache_sync_lock,
                        std::string llm_cache_object_name,
                        std::string llm_ref_cnt_object_name)
                         -> std::shared_ptr<KVCacheManager> {
              VineyardCacheConfig config(
                  tensor_nbytes, cache_capacity, layer, block_size,
-                 sync_interval, llm_cache_sync_lock, llm_cache_object_name,
+                 sync_interval, cache_access_lock_timeout_ms,
+                 llm_cache_sync_lock, llm_cache_object_name,
                  llm_ref_cnt_object_name);
              Client& client = ipc_client.cast<Client&>();
              std::shared_ptr<KVCacheManager> manager;
@@ -85,6 +87,7 @@ PYBIND11_MODULE(_llm_C, m) {
            py::arg("ipc_client"), py::arg("tensor_nbytes") = 1024,
            py::arg("cache_capacity") = 1024, py::arg("layer") = 1,
            py::arg("block_size") = 16, py::arg("sync_interval") = 3,
+           py::arg("cache_access_lock_timeout_ms") = 10,
            py::arg("llm_cache_sync_lock") = "llmCacheSyncLock",
            py::arg("llm_cache_object_name") = "llm_cache_object",
            py::arg("llm_ref_cnt_object_name") = "llm_refcnt_object")

--- a/python/vineyard/llm/cache.py
+++ b/python/vineyard/llm/cache.py
@@ -55,6 +55,7 @@ class VineyardCacheConfig:
         socket: str,
         block_size: int = 5,
         sync_interval: int = 3,
+        cache_access_lock_timeout_ms: int = 10,
         llm_cache_sync_lock: str = "llmCacheSyncLock",
         llm_cache_object_name: str = "llm_cache_object",
         llm_ref_cnt_object_name: str = "llm_refcnt_object",
@@ -68,6 +69,9 @@ class VineyardCacheConfig:
                 The block size of the kv cache. Defaults to 5.
             sync_interval (int, optional):
                 The sync interval of the kv cache. Defaults to 3.
+            cache_access_lock_timeout_ms (int, optional):
+                The access lock timeout (in milliseconds) of the kv cache.
+                Defaults to 10.
             llm_cache_sync_lock (str, optional):
                 The name of the kv cache sync lock. Defaults to "llmCacheSyncLock".
             llm_cache_object_name (str, optional):
@@ -80,6 +84,7 @@ class VineyardCacheConfig:
 
         self.block_size = block_size
         self.sync_interval = sync_interval
+        self.cache_access_lock_timeout_ms = cache_access_lock_timeout_ms
         self.llm_cache_sync_lock = llm_cache_sync_lock
         self.llm_cache_object_name = llm_cache_object_name
         self.llm_ref_cnt_object_name = llm_ref_cnt_object_name
@@ -93,6 +98,7 @@ class VineyardCacheConfig:
             f'ipc_client={self.ipc_client}, '
             f'block_size={self.block_size}, '
             f'sync_interval={self.sync_interval}, '
+            f'cache_access_lock_timeout_ms={self.cache_access_lock_timeout_ms}, '
             f'llm_cache_sync_lock={self.llm_cache_sync_lock}, '
             f'llm_cache_object_name={self.llm_cache_object_name}, '
             f'llm_ref_cnt_object_name={self.llm_ref_cnt_object_name})'
@@ -223,6 +229,12 @@ class KVCache:  # pylint: disable=too-many-instance-attributes
                 )
                 _argument_from_env(
                     config, 'VINEYARD_LLM_CACHE_SHARED_MEMORY', 'sync_interval', int
+                )
+                _argument_from_env(
+                    config,
+                    'VINEYARD_LLM_CACHE_SHARED_MEMORY',
+                    'cache_access_lock_timeout_ms',
+                    int,
                 )
                 cache_config = VineyardCacheConfig(**config)
             if 'VINEYARD_LLM_CACHE_FILESYSTEM' in os.environ:

--- a/python/vineyard/llm/tests/test_llm.py
+++ b/python/vineyard/llm/tests/test_llm.py
@@ -30,6 +30,7 @@ def test_kv_cache_update_and_query_on_blob(vineyard_ipc_sockets):
         socket=vineyard_ipc_sockets[0],
         block_size=5,
         sync_interval=3,
+        cache_access_lock_timeout_ms=10,
         llm_cache_sync_lock="llmCacheSyncLock",
         llm_cache_object_name="llm_cache_object",
         llm_ref_cnt_object_name="llm_refcnt_object",


### PR DESCRIPTION
v1 API enhancement
- support trying lock for a configurable duration to reduce number of exceptions caused by lock contention
- configurable w/ env: VINEYARD_LLM_CACHE_SHARED_MEMORY_CACHE_ACCESS_LOCK_TIMEOUT_MS

